### PR TITLE
Fix Permissions to use ID instead of Level

### DIFF
--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -31,7 +31,7 @@ class Permission extends Model implements HasBadge
             ->with([
                 'users:id,username,look,rank,online',
                 'users.activeBadges'
-            ])->orderByDesc('level')
+            ])->orderByDesc('id')
             ->get();
     }
 


### PR DESCRIPTION
Level is used for Emulator permission level to access certain features. Don't use that for displaying the list